### PR TITLE
issue: register_check_parameters() got an unexpected keyword argument 'match_type'

### DIFF
--- a/slapd/web/plugins/wato/check_parameters_slapd_instance.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_instance.py
@@ -23,5 +23,5 @@ register_check_parameters(
         title = _("Instance"),
         help = _("Only needed if you have multiple SLAPD Instances on one server"),
     ),
-    match_type = "dict",
+    "dict",
 )

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_connections.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_connections.py
@@ -40,5 +40,5 @@ register_check_parameters(
         title = _("Instance"),
         help = _("Only needed if you have multiple SLAPD Instances on one server"),
     ), #instance
-    match_type = "dict",
+    "dict",
 )

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_operations.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_operations.py
@@ -112,5 +112,5 @@ register_check_parameters(
         title = _("Instance"),
         help = _("Only needed if you have multiple SLAPD Instances on one server"),
     ), #instance
-    match_type = "dict",
+    "dict",
 )

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_statistics.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_statistics.py
@@ -49,5 +49,5 @@ register_check_parameters(
         title = _("Instance"),
         help = _("Only needed if you have multiple SLAPD Instances on one server"),
     ), #instance
-    match_type = "dict",
+    "dict",
 )

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_waiters.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_waiters.py
@@ -31,5 +31,5 @@ register_check_parameters(
         title = _("Instance Name"),
         help = _("Only needed if you have multiple SLAPD Instances on one server"),
     ),
-    match_type = "dict",
+    "dict",
 )

--- a/slapd/web/plugins/wato/check_parameters_slapd_syncrepl.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_syncrepl.py
@@ -22,5 +22,5 @@ register_check_parameters(
         title = _("Instance"),
         help = _("Only needed if you have multiple SLAPD Instances on one server"),
     ), #instance
-    match_type = "dict",
+    "dict",
 )


### PR DESCRIPTION
This is running under 1.2.6p14
