### PR TITLE
Fix group for slapd

### DIFF
--- a/slapd/web/plugins/wato/check_parameters_slapd_instance.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_instance.py
@@ -1,6 +1,3 @@
-checkgroups = []
-subgroup_applications = _("Applications, Processes & Services")
-
 register_check_parameters(
     subgroup_applications,
     "slapd_instance",

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_connections.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_connections.py
@@ -1,6 +1,3 @@
-checkgroups = []
-subgroup_applications = _("Applications, Processes & Services")
-
 register_check_parameters(
     subgroup_applications,
     "slapd_stats_connections",

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_operations.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_operations.py
@@ -1,6 +1,3 @@
-checkgroups = []
-subgroup_applications = _("Applications, Processes & Services")
-
 register_check_parameters(
     subgroup_applications,
     "slapd_stats_operations",

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_statistics.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_statistics.py
@@ -1,6 +1,3 @@
-checkgroups = []
-subgroup_applications = _("Applications, Processes & Services")
-
 register_check_parameters(
     subgroup_applications,
     "slapd_stats_statistics",

--- a/slapd/web/plugins/wato/check_parameters_slapd_stats_waiters.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_stats_waiters.py
@@ -1,6 +1,3 @@
-checkgroups = []
-subgroup_applications = _("Applications, Processes & Services")
-
 register_check_parameters(
     subgroup_applications,
     "slapd_stats_waiters",

--- a/slapd/web/plugins/wato/check_parameters_slapd_syncrepl.py
+++ b/slapd/web/plugins/wato/check_parameters_slapd_syncrepl.py
@@ -1,6 +1,3 @@
-checkgroups = []
-subgroup_applications = _("Applications, Processes & Services")
-
 register_check_parameters(
     subgroup_applications,
     "slapd_syncrepl",


### PR DESCRIPTION
Fix group for slapd to enable check in WATO's Applications, Processes & Services. Otherwise it is not visible.